### PR TITLE
Optionally create dependency on EPEL module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This module has been built on and tested against Puppet 5 and higher.
 
 The module has been tested on:
 
-* Red Hat/CentOS Enterprise Linux 6/7
+* RedHat Enterprise/CentOS Linux 6/7/8
 * Ubuntu 14.04/16.04
 * Debian 7/8
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ previous commits.
 
 On RHEL/CentOS platforms you will need to have access to the EPEL repository
 by using [puppet/epel](https://forge.puppet.com/puppet/epel) or by other
-means.
+means.  If using the EPEL repository module, this module will include it by
+default.  To override, set `assume_epel` to True.
 
 ### Beginning with etckeeper
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,5 @@
 ---
+etckeeper::assume_epel: ~
 etckeeper::avoid_commit_before_install: ~
 etckeeper::avoid_daily_autocommits: ~
 etckeeper::avoid_special_file_warning: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,7 @@
 # @!visibility private
 class etckeeper::config {
 
+  $assume_epel                 = $etckeeper::assume_epel
   $avoid_commit_before_install = $etckeeper::avoid_commit_before_install
   $avoid_daily_autocommits     = $etckeeper::avoid_daily_autocommits
   $avoid_special_file_warning  = $etckeeper::avoid_special_file_warning

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@
 #     vcs_user_email => 'alice@example.com',
 #   }
 #
+# @param assume_epel Assume EPEL repository installed (Red Hat variants only)
 # @param avoid_commit_before_install
 # @param avoid_daily_autocommits
 # @param avoid_special_file_warning
@@ -37,6 +38,7 @@
 #
 # @since 1.0.0
 class etckeeper (
+  Optional[Boolean]                    $assume_epel,
   Optional[Boolean]                    $avoid_commit_before_install,
   Optional[Boolean]                    $avoid_daily_autocommits,
   Optional[Boolean]                    $avoid_special_file_warning,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 class etckeeper::install {
 
   # if RedHat, need to have EPEL installed
-  if $::osfamily == 'RedHat' {
+  if $::osfamily == 'RedHat' and ! $::etckeeper::assume_epel {
     include ::epel
     Class['::epel'] -> Package[$::etckeeper::package_name]
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,12 @@
 # @!visibility private
 class etckeeper::install {
 
-  package { $etckeeper::package_name:
+  # if RedHat, need to have EPEL installed
+  if $::osfamily == 'RedHat' {
+    include ::epel
+    Class['::epel'] -> Package[$::etckeeper::package_name]
+  }
+  package { $::etckeeper::package_name:
     ensure => present,
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,12 @@ class etckeeper::install {
 
   # if RedHat, need to have EPEL installed
   if $::osfamily == 'RedHat' and ! $::etckeeper::assume_epel {
-    include ::epel
-    Class['::epel'] -> Package[$::etckeeper::package_name]
+    if defined(Class['epel']) {
+      Class['epel'] -> Package[$::etckeeper::package_name]
+    }
+    else {
+      warning("Without EPEL repository configured, I probably won't be able to find package ${::etckeeper::package_name}.  See \$assume_epel for more information.")
+    }
   }
   package { $::etckeeper::package_name:
     ensure => present,


### PR DESCRIPTION
These changes create, for systems in the Red Hat OS family, a dependency on the [EPEL module](https://forge.puppet.com/puppet/epel).  While the EPEL repository is a prerequisite for Red Hat variants to use this module, if the repository is configured manually or otherwise already exists then the dependency can be overridden via a parameter: `$assume_epel = true`.

## Context

We have been using this module to manage etckeeper on CentOS 7 systems without any issue.  However on a new CentOS 8 build this module initializes before the EPEL repository is configured.