### PR TITLE
Drop old Puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=5.5.10 <8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Increase upper bound to support 6/7.

Fixes #14