### PR TITLE
Add "is it already defined" check on vcs package installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,9 +7,11 @@ class etckeeper::install {
 
   if $etckeeper::manage_vcs_package {
     if has_key($etckeeper::vcs_packages, $etckeeper::vcs) {
-      package { $etckeeper::vcs_packages[$etckeeper::vcs]:
-        ensure  => present,
-        require => Package[$etckeeper::package_name],
+      if !defined(Package[$etckeeper::vcs_packages[$etckeeper::vcs]] {
+        package { $etckeeper::vcs_packages[$etckeeper::vcs]:
+          ensure  => present,
+          require => Package[$etckeeper::package_name],
+        }
       }
     } else {
       fail("No package available for VCS ${etckeeper::vcs}.")


### PR DESCRIPTION
Add a check if the vcs package is already defined elsewhere, to make this simpler/easier to work with if something else in the manifests installs git or other vcs.

I ran into a surprise conflict because somewhere else one of my modules also installed 'git'. The other module had a `if !defined` on the git package install, but happened to get hit first randomly.

Yes, you can work around this pretty simply with ` manage_vcs_package => false`, but I think this change would make the module easier to work with.